### PR TITLE
Replace Issue Templates with Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing-test-case-en.yaml
+++ b/.github/ISSUE_TEMPLATE/missing-test-case-en.yaml
@@ -1,0 +1,111 @@
+---
+name: Missing Test Case
+description: Report a missing test case to help us improve our content.
+title: "Missing Test Case - <problem ID and name>"
+labels: ["LCUS", "watchlist", "problem"]
+assignees:
+  - LC-Pam
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to fill out this report!
+  - type: input
+    id: username
+    attributes:
+      label: LeetCode username
+      description: >
+        Please enter your LeetCode username so that we can reward
+        your contribution when the issue is resolved.
+    validations:
+      required: false
+  - type: textarea
+    id: "description"
+    attributes:
+      label: Bug description
+      description: A clear and concise description of what the bug is.
+      placeholder: >
+        The submission below currently gets AC, 
+        but should get WA because ...
+    validations:
+      required: true
+  - type: dropdown
+    id: expected
+    attributes:
+      label: Expected verdict
+      description: What verdict you expected to get instead of Accepted?
+      options:
+        - Wrong Answer
+        - Time Limit Exceeded
+        - Runtime Error
+        - Memory Limit Exceeded
+    validations:
+      required: true
+  - type: textarea
+    id: code
+    attributes:
+      label: Code
+      description: |
+        Code you used for Submit/Run operation.
+        This will be automatically formatted as code, so no need for backticks.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: test
+    attributes:
+      label: Missing Test Case
+      description: |
+        What is the missing test case?
+        You can attach a file if your test case is too big to copy-paste.
+        If you want to, you can also share a generator, preferably in Python3.
+    validations:
+      required: true
+  - type: dropdown  # this chould be an input
+    id: language
+    attributes:
+      label: Language
+      description: Language used for code
+      options:
+        - C++
+        - Java
+        - Python
+        - Python3
+        - C
+        - "C#"
+        - JavaScript
+        - Ruby
+        - Swift
+        - Go
+        - Scala
+        - Kotlin
+        - Rust
+        - PHP
+        - Typescript
+        - Racket
+        - Erlang
+        - Elixir
+        - Dart
+        - MySQL
+        - MS SQL Server
+        - Oracle
+        - Bash
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other additional context about the bug.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Terms of Service
+      description: >
+        By submitting this issue, you agree to our
+        [Terms of Service](https://leetcode.com/terms/)
+      options:
+        - label: I agree to this project's Terms of Service
+          required: true
+...


### PR DESCRIPTION
On the week of March 20th, 137 issues were [created](https://github.com/LeetCode-Feedback/LeetCode-Feedback/issues?q=is%3Aissue+created%3A2023-03-20..2023-03-26), with the dominant category being 89 [missing test cases](https://github.com/LeetCode-Feedback/LeetCode-Feedback/issues?q=is%3Aissue+created%3A2023-03-20..2023-03-26+in%3Atitle+Missing+Test+Case). Roughly 50% of the reports are empty, and an additional 25% lack some fields, meaning that only 1-in-4 issues provide complete info from the get-go. This highlights the need for validation of issues. 

GitHub’s [Issue Forms](https://www.youtube.com/watch?v=qQE1BUkf2-s&ab_channel=GitHub) address this problem. I provide an issue form for missing test cases as a starting point. You can preview the user experience by opening the [new .yaml file](https://github.com/nskybytskyi/LeetCode-Feedback/blob/issueforms/.github/ISSUE_TEMPLATE/missing-test-case-en.yaml) on GitHub. Please let me know if you need issue forms for other bug categories, such as solutions or questions. Sadly, I cannot help you translate these to Chinese, like the old issue templates.

A checklist will appear here soon after discussing this PR with @Miloas and @LC-Pam.