### PR TITLE
Update English issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-english.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-english.yml
@@ -7,14 +7,9 @@ body:
     id: username
     attributes:
       label: "LeetCode Username"
-      description: Click your avatar in the top right on the problem page after logging in to find your username.
-    validations:
-      required: true
-  - type: input
-    id: problem-details
-    attributes:
-      label: "Problem Number, Title, and Link"
-      placeholder: 1. Two Sum https://leetcode.com/problems/two-sum/
+      description: >
+        You can find your username (LeetCode ID) in the "Account Information"
+        section of your [Profile page](https://leetcode.com/profile/account/).
     validations:
       required: true
   - type: dropdown
@@ -28,9 +23,11 @@ body:
         - Problem constraints
         - Problem hints
         - Incorrect or missing "Related Topics"
-        - Incorrect test case *(Output of test case is incorrect as per the problem statement)*
-        - Missing test case *(Incorrect/Inefficient Code getting accepted because of missing test cases)*
+        - Incorrect test case (Output of test case is incorrect as per the problem statement)
+        - Missing test case (Incorrect/Inefficient Code getting accepted because of missing test cases)
         - Editorial
+        - Explore Card
+        - Interview Crash Course
     validations:
       required: true
   - type: textarea
@@ -40,6 +37,29 @@ body:
       description: A clear and concise description of what the bug is.
     validations:
       required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "Expected behavior"
+      description: >
+        A clear and concise description of what was expected to happen
+        in contrast with what happened.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: "Screenshots"
+      description: If applicable, add screenshots to explain the issue.
+    validations:
+      required: false
+  - type: input
+    id: problem-details
+    attributes:
+      label: "Problem Number, Title, and Link"
+      placeholder: 1. Two Sum https://leetcode.com/problems/two-sum/
+    validations:
+      required: false
   - type: dropdown
     id: language-used
     attributes:
@@ -74,29 +94,15 @@ body:
   - type: textarea
     id: code
     attributes:
-      label: Code used for Submit/Run operation
+      label: "Code used for Submit/Run operation"
       description: Please copy and paste the complete code you used for submit/run operation. This will be automatically formatted into code, so no need for backticks.
       render: bash
     validations:
       required: false
   - type: textarea
-    id: expected-behavior
-    attributes:
-      label: Expected behavior
-      description: A clear and concise description of what was expected to happen in contrast with what happened.
-    validations:
-      required: true
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots
-      description: If applicable, add screenshots to explain the issue.
-    validations:
-      required: false
-  - type: textarea
     id: additional-context
     attributes:
-      label: Additional context
+      label: "Additional context"
       description: Add any other additional context about the bug.
     validations:
       required: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](./README-CN.md)
 
-With LeetCode-Feedback, we are providing a more transparent method for filing content-related issues you've encountered on [LeetCode](https://leetcode.com)/[LeetCode China](https://leetcode.cn). To share these issues with us, you can create an issue in this Github repo.
+With LeetCode-Feedback, we are providing a more transparent method for filing content-related issues you've encountered on [LeetCode](https://leetcode.com)/[LeetCode China](https://leetcode.cn). To share these issues with us, you can create an issue in this GitHub repo.
 
 Below are the types of issues that will fall under this filing method:
 
@@ -15,10 +15,10 @@ Below are the types of issues that will fall under this filing method:
     * Incorrect existing test cases
     * Missing test cases
 
-* Editorial content issues such as:
+* Editorial, Explore Card and Crash Interview Course content issues such as:
     * Missing approach
     * Video errors
-    * Editorial code is not workings
+    * Broken code
     * Animation/figure related issues
 
 For any other billing or site-related issues, please reach out to us via our [Help Center](https://support.leetcode.com/hc/en-us).


### PR DESCRIPTION
This PR continues the initiative started in #14361. The English issue template was updated with the following changes:

- Changed the description of the "LeetCode Username" field because the previous one was not correct (two different users may have the same name in the "Basic Info" profile section)
- Moved the "Bug Category", "Bug Description", and "Expected Behavior" fields to the "LeetCode Username", as they are the most important
- Added missing bug categories (Explore Card and Interview Crash Course), updated `README.md` with the same changes
- Made "Problem Number, Title, and Link" optional, since some content issues may not be related to an actual problem

Would be very grateful for a review: @luciphania and @wktang